### PR TITLE
Reduce requirement for multiple presentations

### DIFF
--- a/docs/grading.md
+++ b/docs/grading.md
@@ -22,8 +22,8 @@ longer descriptions of each metric).
 |--------------|------------|--------------------------------|--------------------------|---------------------------|---------------------------|-----------------------|----------------------|
 | 1            | 2          | 3 absences, 1 bonus session    | 1                        | 2                         | 0                         | X                     | X                    |
 | 2            | 3          | 3 absences, 2 bonus sessions   | 3                        | 2                         | 1                         | X                     | X                    |
-| 3            | 4          | 2 absences, 2 bonus sessions   | 5                        | 2                         | 2                         | X                     | Yes                  |
-| 4            | 4          | 2 absences, 2 bonus sessions   | 7                        | 2                         | 2                         | Yes                   | Yes                  |
+| 3            | 4          | 2 absences, 2 bonus sessions   | 5                        | 2                         | 1                         | X                     | Yes                  |
+| 4            | 4          | 2 absences, 2 bonus sessions   | 7                        | 2                         | 1                         | Yes                   | Yes                  |
 
 ## Grading Metrics
 


### PR DESCRIPTION
Reduce requirement for multiple presentations from the same group in one semester.  It was previously decided that we'd be doing one presentation per group per semester because one of the presentations was always redundant as well as not having enough bandwidth to have everyone present twice.

We should change this requirement to reflect our previous decision.
