### PR TITLE
Create file containing all mentors/advisors/faculty involved

### DIFF
--- a/docs/CoordinatorsSpring2017.md
+++ b/docs/CoordinatorsSpring2017.md
@@ -1,0 +1,30 @@
+Here you find a list of 
+##Faculty Advisors
+Moorthy
+Goldschmidt
+Wes Turner 
+
+##Spring 2017 Coordinators
+Kiana 
+Richie 
+Brian 
+Adrian 
+
+##Spring 2017 Mentors
+Adrian Collado
+Andrew Kaiser
+Alexander Schwartzberg
+Beverly Sihsobhon
+Brian Kelley
+Conner Foody
+Kathleen Burkhardt
+Lucien Christie-Dervaux
+Max Shavrick
+John Behnke
+Richie Young
+Cameron Root
+Patrick Celentano
+Joey Lee
+Zaran Lalvani
+Toshi Piazza
+Zefanya Putri

--- a/docs/CoordinatorsSpring2017.md
+++ b/docs/CoordinatorsSpring2017.md
@@ -1,11 +1,11 @@
 Here you find a list of cooordinators/advisors/mentors for RCOS.
 
 ##Faculty Advisors
-Moorthy - mskmoorthy@gmail.com
+Moorthy
 
-Goldschmidt - goldschmidt@gmail.com
+Goldschmidt 
 
-Wes Turner - turnew2@rpi.edu
+Wes Turner
 
 ##Spring 2017 Coordinators
 Kiana 

--- a/docs/CoordinatorsSpring2017.md
+++ b/docs/CoordinatorsSpring2017.md
@@ -1,11 +1,11 @@
-Here you find a list of cooordinators/advidors/mentors for RCOS.
+Here you find a list of cooordinators/advisors/mentors for RCOS.
 
 ##Faculty Advisors
-Moorthy
+Moorthy - mskmoorthy@gmail.com
 
-Goldschmidt
+Goldschmidt - goldschmidt@gmail.com
 
-Wes Turner 
+Wes Turner - turnew2@rpi.edu
 
 ##Spring 2017 Coordinators
 Kiana 

--- a/docs/CoordinatorsSpring2017.md
+++ b/docs/CoordinatorsSpring2017.md
@@ -1,30 +1,52 @@
-Here you find a list of 
+Here you find a list of cooordinators/advidors/mentors for RCOS.
+
 ##Faculty Advisors
 Moorthy
+
 Goldschmidt
+
 Wes Turner 
 
 ##Spring 2017 Coordinators
 Kiana 
+
 Richie 
+
 Brian 
+
 Adrian 
 
 ##Spring 2017 Mentors
 Adrian Collado
+
 Andrew Kaiser
+
 Alexander Schwartzberg
+
 Beverly Sihsobhon
+
 Brian Kelley
+
 Conner Foody
+
 Kathleen Burkhardt
+
 Lucien Christie-Dervaux
+
 Max Shavrick
+
 John Behnke
+
 Richie Young
+
 Cameron Root
+
 Patrick Celentano
+
 Joey Lee
+
 Zaran Lalvani
+
 Toshi Piazza
+
 Zefanya Putri


### PR DESCRIPTION
I think it would be helpful to create a file containing all of mentors/advisors/faculty involved in RCOS so that it's easy to see who to contact/who's involved for each semester. All of the info in this file is currently in the index.html page, however if that is being overwritten each semester this info will be lost so it is a good way to keep track of people previously involved in RCOS as well.