### PR TITLE
add code of conduct related docs, update goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Finding a team in RCOS isn't a requirement, but can often make RCOS easier for e
 
 [Github](https://github.com/) is where most RCOS projects are stored and collaborated on within. You will need to create an account and eventually create or join a project.
 
+## Code of Conduct
+
+Our **Community Code of Conduct** outlines some common ground rules all RCOS members are expected to abide by in order to make RCOS an inclusive experience for everyone. You can find the RCOS Community Code of Conduct [here](https://github.com/rcos/intro/blob/master/docs/code_of_conduct.md). 
+
+In addition to following the Community Code of Conduct, we strongly suggest that your project's repository includes a Code of Conduct as well. You can find a Code of Conduct template for your project that includes an abbreviated version of our Code of Conduct as well as space for any project-specific ground rules [here](https://github.com/rcos/intro/blob/master/docs/project_coc_template.md). In addition, Github has instructions on including a Code of Conduct in your project [here](https://help.github.com/articles/adding-a-code-of-conduct-to-your-project/).
+
 ## Getting Help
 
 Your mentors will help you all along the way. If you have any questions, find your mentor and ask. If you don't have a mentor or you've forgotten your mentor, talk to a coordinator.
@@ -84,11 +90,13 @@ Student's who take RCOS for credit must be evaluated and given a letter grade. T
 
 If you'd like to see a more refined set of guidelines, see the formal [grading rubric](https://github.com/rcos/intro/blob/master/docs/grading.md).
 
-## Our goals in RCOS (S2016)
+## Our goals in RCOS (S2018)
 
 * Get more contributions to external projects (projects created outside RCOS)
-* Increase the rate of success and of RCOS projects
 * Increase the longevity of RCOS projects
+* Collaborate with other organizations, including MOSSN (Mozilla Open Source Student Network)
+* Offer alternative ways to learn and get involved (not just coding)
+* Have more student talks and bonus sessions
 
 ## What do you do now?
 

--- a/docs/code_of_conduct.md
+++ b/docs/code_of_conduct.md
@@ -2,7 +2,7 @@
 In the interest of fostering an open and welcoming environment, RCOS pledges to be an inclusive and harassment-free experience for  all, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, educational background, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation. 
 
 ## General
-The General Code of Conduct applies to all RCOS and [your project]-affiliated activity online and offline.
+The General Code of Conduct applies to all RCOS activity and activity affiliated with any RCOS project online and offline.
 
 ### Guidelines
 #### Be respectful and inclusive
@@ -34,10 +34,10 @@ Examples of unacceptable behaviors include:
 
 ### Reporting Incidents
 
-At any point, you may report instances of CoC violations to RCOS faculty at [insert contact info]. You, as well as any other witnesses, have the right to remain anonymous to the rest of the RCOS community.
+At any point, you may report instances of CoC violations to RCOS faculty at <coordinators@rcos.io>. You, as well as any other witnesses, have the right to remain anonymous to the rest of the RCOS community.
 
 ### Project Maintainer Responsibilities
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. In the case of contributors external to RPI and/or RCOS, temporary or permanent bans may occur (RPI-specific policies are outlined [here](insert link to rpi specific stuff)).
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. In the case of contributors external to RPI and/or RCOS, temporary or permanent bans may occur. RPI-specific policies are outlined below.
 
 ## RPI-Specific Policies
 

--- a/docs/project_coc_template.md
+++ b/docs/project_coc_template.md
@@ -1,0 +1,47 @@
+# [Your Project] Code of Conduct
+In the interest of fostering an open and welcoming environment, [your project] pledges to be an inclusive and harassment-free experience for  all, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, educational background, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation. 
+
+## General
+The General Code of Conduct applies to all [your project]-affiliated activity online and offline.
+
+### Guidelines
+#### Be respectful and inclusive
+* **Use inclusive language.**  This includes:
+  * using [gender-neutral or non-gendered language](http://geekfeminism.wikia.com/wiki/Nonsexist_language) where possible 
+  * when referring to community members, using their preferred pronouns 
+  * in general, avoiding any language that could be considered offensive towards marginalized groups
+* **Respect people's differences.** Examples include:
+  * Being welcoming towards new members
+  * Being open to opposing viewpoints
+  * Being understanding of cultural differences
+  * Making sure your project and any physical spaces your project team may meet are accessible to all members, including members with disabilities
+
+#### Give and be welcoming to constructive feedback
+* **Be constructive and respectful** when giving others feedback. This includes:
+  * Only giving feedback when solicited (e.g. mock presentation, questions section of presentation, request for code review, pull request, etc.)
+  * Keeping all feedback constructive, objective and impersonal
+
+
+### Unacceptable Behaviors
+
+Examples of unacceptable behaviors include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others’ private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+### Reporting Incidents
+
+This project is affiliated with [Rensselaer Center for Open Source](http://rcos.io) (RCOS). At any point, you may report instances of CoC violations to RCOS faculty at <coordinators@rcos.io>. You, as well as any other witnesses, have the right to remain anonymous to the rest of the RCOS community.
+
+### Project Maintainer Responsibilities
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. In the case of contributors external to RPI and/or RCOS, temporary or permanent bans may occur. RPI-specific policies are outlined in the RCOS Community Code of Conduct, which can be found under "License and Attribution".
+
+## [Your Project]-Specific Guidelines 
+Add any additional ground rules you would like your project team to follow (if any) here.
+
+## License and Attribution
+
+This Code of Conduct has been abbreviated and adapted from the [RCOS Community Code of Conduct](https://github.com/rcos/intro/blob/master/docs/code_of_conduct.md). 

--- a/presentation/code_of_conduct.html
+++ b/presentation/code_of_conduct.html
@@ -110,7 +110,7 @@
                 <section>
                   <h2>Add the RCOS Community Code of Conduct to Your Project</h2>
                   <p class="fragment">Follow GitHub's instructions for adding a code of conduct: <a href="http://bit.ly/2mXVZhO">bit.ly/2mXVZhO</a></p>
-                  <p class="fragment">In the CODE_OF_CONDUCT.md file you created, copy and paste the Code of Conduct template found in the RCOS intro repository under "docs".</p>
+                  <p class="fragment">In the CODE_OF_CONDUCT.md file you created, copy and paste the Code of Conduct template found in the RCOS intro repository under "docs". It should be titled "project_coc_template.md".</p>
                 </section>
 
                 <section>


### PR DESCRIPTION
This PR:

- Finishes up the Code of Conduct (adds missing links)
- Adds a Code of Conduct template for RCOS projects
- Adds Code of Conduct info to the README
- Updates goals for 2018 (the current goals in the README are 2 years out of date)